### PR TITLE
chore: update nginx ingress controller to 1.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Kubernetes Fury Ingress provides the following packages:
 
 | Package                                       | Version    | Description                                                                                                                   |
 | --------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| [nginx](katalog/nginx)                        | `v1.12.0`  | The NGINX Ingress Controller for Kubernetes provides delivery services for Kubernetes applications.                           |
-| [dual-nginx](katalog/dual-nginx)              | `v1.12.0`  | It deploys two identical NGINX ingress controllers but with two different scopes: public/external and private/internal.       |
+| [nginx](katalog/nginx)                        | `v1.12.1`  | The NGINX Ingress Controller for Kubernetes provides delivery services for Kubernetes applications.                           |
+| [dual-nginx](katalog/dual-nginx)              | `v1.12.1`  | It deploys two identical NGINX ingress controllers but with two different scopes: public/external and private/internal.       |
 | [cert-manager](katalog/cert-manager)          | `v1.16.1`  | cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources. |
 | [external-dns](katalog/external-dns)          | `v0.16.1`  | external-dns allows you to manage DNS records natively from Kubernetes.                                                       |
 | [forecastle](katalog/forecastle)              | `v1.0.156` | Forecastle gives you access to a control panel where you can see your ingresses and access them on Kubernetes.                |

--- a/docs/releases/v4.0.0.md
+++ b/docs/releases/v4.0.0.md
@@ -45,6 +45,8 @@ Upstream Ingress NGINX Controller has introduced some breaking changes in versio
 
   It also removes support for user provided Lua plugins in the `/etc/nginx/lua/plugins` directory.
 
+Upstream Ingress NGINX Controller has also corrected a few critical CVEs in version 1.12.1, included in this version of the ingress module. We recommend reading [upstream's changelog](https://github.com/kubernetes/ingress-nginx/blob/main/changelog/controller-1.12.1.md) to check if you have been impacted.
+
 ## external-dns
 
 A breaking change has been introduced in v0.16.0 for the Cloudflare provider, please see [this link](https://github.com/kubernetes-sigs/external-dns/issues/5166) for more details.

--- a/katalog/dual-nginx/README.md
+++ b/katalog/dual-nginx/README.md
@@ -12,7 +12,7 @@ Ingress NGINX is an Ingress Controller for [NGINX][nginx-page] webserver and rev
 
 ## Image repository and tag
 
-- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.12.0`
+- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.12.1`
 - Ingress NGINX repo: [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
 
 ## Configuration

--- a/katalog/nginx/README.md
+++ b/katalog/nginx/README.md
@@ -12,7 +12,7 @@ Ingress NGINX is an Ingress Controller for [NGINX][nginx-page] web server and re
 
 ## Image repository and tag
 
-- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.12.0`
+- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.12.1`
 - Ingress NGINX repo: [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
 
 ## Configuration

--- a/katalog/nginx/bases/configs/ClusterRole-ingress-nginx.yml
+++ b/katalog/nginx/bases/configs/ClusterRole-ingress-nginx.yml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
   name: ingress-nginx

--- a/katalog/nginx/bases/configs/ClusterRoleBinding-ingress-nginx.yml
+++ b/katalog/nginx/bases/configs/ClusterRoleBinding-ingress-nginx.yml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
   name: ingress-nginx

--- a/katalog/nginx/bases/configs/PrometheusRule-ingress-nginx-controller.yml
+++ b/katalog/nginx/bases/configs/PrometheusRule-ingress-nginx-controller.yml
@@ -13,7 +13,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/configs/Role-ingress-nginx.yml
+++ b/katalog/nginx/bases/configs/Role-ingress-nginx.yml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/configs/RoleBinding-ingress-nginx.yml
+++ b/katalog/nginx/bases/configs/RoleBinding-ingress-nginx.yml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/configs/Service-ingress-nginx-controller-metrics.yml
+++ b/katalog/nginx/bases/configs/Service-ingress-nginx-controller-metrics.yml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/configs/ServiceAccount-ingress-nginx.yml
+++ b/katalog/nginx/bases/configs/ServiceAccount-ingress-nginx.yml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/configs/ServiceMonitor-ingress-nginx-controller.yml
+++ b/katalog/nginx/bases/configs/ServiceMonitor-ingress-nginx-controller.yml
@@ -13,7 +13,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/controller/ConfigMap-ingress-nginx-controller.yml
+++ b/katalog/nginx/bases/controller/ConfigMap-ingress-nginx-controller.yml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/controller/DaemonSet-ingress-nginx-controller.yml
+++ b/katalog/nginx/bases/controller/DaemonSet-ingress-nginx-controller.yml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -36,7 +36,7 @@ spec:
         helm.sh/chart: ingress-nginx-4.12.0
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/version: "1.12.0"
+        app.kubernetes.io/version: "1.12.1"
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: controller
@@ -46,7 +46,7 @@ spec:
         fsGroup: 101
       containers:
         - name: controller
-          image: registry.sighup.io/fury/ingress-nginx/controller:v1.12.0
+          image: registry.sighup.io/fury/ingress-nginx/controller:v1.12.1
           imagePullPolicy: Always
           lifecycle:
             preStop:

--- a/katalog/nginx/bases/controller/IngressClass-nginx.yml
+++ b/katalog/nginx/bases/controller/IngressClass-nginx.yml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/controller/Service-ingress-nginx-controller-admission.yml
+++ b/katalog/nginx/bases/controller/Service-ingress-nginx-controller-admission.yml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/controller/Service-ingress-nginx-controller.yml
+++ b/katalog/nginx/bases/controller/Service-ingress-nginx-controller.yml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/controller/ValidatingWebhookConfiguration-ingress-nginx-admission.yml
+++ b/katalog/nginx/bases/controller/ValidatingWebhookConfiguration-ingress-nginx-admission.yml
@@ -16,7 +16,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.12.0"
+    app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook

--- a/katalog/nginx/bases/controller/kustomization.yaml
+++ b/katalog/nginx/bases/controller/kustomization.yaml
@@ -16,7 +16,7 @@ labels:
 images:
   - name: k8s.gcr.io/ingress-nginx/controller
     newName: registry.sighup.io/fury/ingress-nginx/controller
-    newTag: v1.11.3
+    newTag: v1.12.1
 
 resources:
   - Certificate-ingress-nginx-admission.yml


### PR DESCRIPTION
### Summary 💡

This PR updates the Nginx Ingress Controller version to v1.12.1 to correct and fix a critical 9.8 vulnerability.

### Description 📝

Relates to [this](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.12.1).

### Breaking Changes 💔
None reported.

### Tests performed 🧪
- [x] Installed a cluster following the getting started guide with v1.31.4 with `ingress.nginx.type: double`, Forecastle is correctly available serving the correct certificate.

### Future work 🔧
None.
