### PR TITLE
fix(dual-nginx): Fix typo in validating-webhook patch for internal and external

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,43 +1,53 @@
 <!--
-Thank you for contributing to this project! You must fill out the information below before we can review this pull request.
-By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull
-request to the best possible team for review.
+Thank you for contributing to this project! You must fill out the information below
+before we can review this pull request.
+
+By explaining why you're making a change (or linking to an issue) and what changes
+you've made, we can triage your pull request to the best possible team for review.
 
 💡 **TIP**
-Remember that you can always open a PR in draft status and fill all the information afterwards.
+Remember that you can always open a PR in draft status and fill all the information
+afterwards.
 
-Opening a PR in draft allows other team members to know that you are working on this change, and let's you have a 
-place to track your work in progress.
+Opening a PR in draft allows other team members to know that you are working on
+this change, and let's you have a place to track your work in progress.
 
-When opening PRs in Draft, don't assign reviewers until the PR is ready for review.  Once you are confortable with the
-status of the PR and all the tests and CI is green, you can assign the reviewers to start the review process.
+When opening PRs in Draft, don't assign reviewers until the PR is ready for review.
+Once you are confortable with the status of the PR and all the tests and CI is green,
+you can assign the reviewers to start the review process.
 -->
 
 ### Summary 💡
 
-<!-- Write a short summary of the changes that this PR introduces and the motivations -->
+<!--
+Write a short summary of the changes that this PR introduces and the motivations
+-->
 
 <!--
-If there's an existing issue for your change, please link to it below inserting a link or the issue number.
-If there's _not_ an existing issue, please open one first if the problem you are solving needs to be clearly identified,
-for example is an error message that other users could get and google it.
+If there's an existing issue for your change, please link to it below inserting a
+link or the issue number. If there's _not_ an existing issue, please open one first
+if the problem you are solving needs to be clearly identified, for example is an
+error message that other users could get and google it.
 -->
+
 Closes:
 
+<!--
+If this PR is related to changes produced in other repos, like a Module, please link
+them below.
+-->
 
-<!-- If this PR is related to changes produced in other repos, like a Module, please link them below. -->
 Relates:
-
 
 ### Description 📝
 
 <!--
 Let us know what you are changing. Share anything that could provide the most context.
-Feel free to add screenshots, code examples, the Description could end up in the release notes to help users adopt
-the new feature or changes that you are introducing.
+Feel free to add screenshots, code examples, the Description could end up in the
+release notes to help users adopt the new feature or changes that you are introducing.
 
-Expand on the reasoning behind some decision that you could have made to help reviewers understand the diff in the PR.
-
+Expand on the reasoning behind some decision that you could have made to help reviewers
+understand the diff in the PR.
 -->
 
 ### Breaking Changes 💔
@@ -52,9 +62,9 @@ If this PR introduces Breaking Changes, please include all the relevant informat
 ### Tests performed 🧪
 
 <!--
-Create a checklist with all the tests that you performed on your changes, being manual or automated.
-If you are opening a Draft PR, you can use the checklist to track the tests that you want to do and mark them once you
-have performed them.
+Create a checklist with all the tests that you performed on your changes, being
+manual or automated. If you are opening a Draft PR, you can use the checklist to
+track the tests that you want to do and mark them once you have performed them.
 Example:
 
 - [ ] Tested the change with SD version X.Y.Z
@@ -64,6 +74,6 @@ Example:
 ### Future work 🔧
 
 <!--
-If there's any future work that could improve or extend on the work you've done in this PR you can mention it so
-this PR can be used as context for that.
+If there's any future work that could improve or extend on the work you've done
+in this PR you can mention it so this PR can be used as context for that.
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ request to the best possible team for review.
 💡 **TIP**
 Remember that you can always open a PR in draft status and fill all the information afterwards.
 
-Opening a PR in draft allows other team members to knwo that you are working on this change, and let's you have a 
+Opening a PR in draft allows other team members to know that you are working on this change, and let's you have a 
 place to track your work in progress.
 
 When opening PRs in Draft, don't assign reviewers until the PR is ready for review.  Once you are confortable with the

--- a/katalog/dual-nginx/external/patch/validating-webhook.yml
+++ b/katalog/dual-nginx/external/patch/validating-webhook.yml
@@ -12,7 +12,8 @@
 
 - op: "replace"
   path: "/metadata/annotations/certmanager.k8s.io~1inject-ca-from"
-  vallue: "ingress-nginx/ingress-nginx-admission-external"
+  value: "ingress-nginx/ingress-nginx-admission-external"
+
 - op: "replace"
   path: "/metadata/annotations/cert-manager.io~1inject-ca-from"
   value: "ingress-nginx/ingress-nginx-admission-external"

--- a/katalog/dual-nginx/internal/patch/validating-webhook.yml
+++ b/katalog/dual-nginx/internal/patch/validating-webhook.yml
@@ -12,7 +12,8 @@
 
 - op: "replace"
   path: "/metadata/annotations/certmanager.k8s.io~1inject-ca-from"
-  vallue: "ingress-nginx/ingress-nginx-admission-internal"
+  value: "ingress-nginx/ingress-nginx-admission-internal"
+
 - op: "replace"
   path: "/metadata/annotations/cert-manager.io~1inject-ca-from"
   value: "ingress-nginx/ingress-nginx-admission-internal"


### PR DESCRIPTION
### Summary 💡

I found two mistyped `value` in the `validating-webhook.yml` patch for internal and external `ValidatingWebhookConfiguration`.

### Description 📝

Self-explanatory

### Breaking Changes 💔

None

### Tests performed 🧪

None

### Future work 🔧

None