### PR TITLE
fix(forecastle): Use SIGHUP Distribution branding

### DIFF
--- a/katalog/forecastle/config.yaml
+++ b/katalog/forecastle/config.yaml
@@ -8,6 +8,6 @@ namespaceSelector:
 crdEnabled: true
 customApps: {}
 instanceName: null
-title: "SIGHUP Kubernetes Distribution - Infrastructure Applications Directory"
-headerBackground: "#421959"
-headerForeground: "#ffffff"
+title: "SIGHUP Distribution - Infrastructure Applications Directory"
+headerBackground: "#1d1e24"
+headerForeground: "#dfe5ef"


### PR DESCRIPTION
### Summary 💡

Update Forecastle branding to SIGHUP Distribution:
<img width="1724" alt="image" src="https://github.com/user-attachments/assets/b54f20ed-70a5-486c-89ec-6e26bcea7a54" />

### Description 📝

See above

### Breaking Changes 💔

Only my heart </3 RIP Fury

### Tests performed 🧪

See screenshot above

### Future work 🔧

Hopefully none