### PR TITLE
feat(nginx): upgrade ingress-nginx-controller to v1.13.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </h1>
 <!-- markdownlint-enable MD033 -->
 
-![Release](https://img.shields.io/badge/Latest%20Release-v4.1.0-blue)
+![Release](https://img.shields.io/badge/Latest%20Release-v4.1.1-blue)
 ![License](https://img.shields.io/github/license/sighupio/fury-kubernetes-ingress?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
@@ -43,8 +43,8 @@ Ingress Module provides the following packages:
 
 | Package                                       | Version    | Description                                                                                                                   |
 | --------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| [nginx](katalog/nginx)                        | `v1.13.1`  | The NGINX Ingress Controller for Kubernetes provides delivery services for Kubernetes applications.                           |
-| [dual-nginx](katalog/dual-nginx)              | `v1.12.1`  | It deploys two identical NGINX ingress controllers but with two different scopes: public/external and private/internal.       |
+| [nginx](katalog/nginx)                        | `v1.13.3`  | The NGINX Ingress Controller for Kubernetes provides delivery services for Kubernetes applications.                           |
+| [dual-nginx](katalog/dual-nginx)              | `v1.13.3`  | It deploys two identical NGINX ingress controllers but with two different scopes: public/external and private/internal.       |
 | [cert-manager](katalog/cert-manager)          | `v1.18.2`  | cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources. |
 | [external-dns](katalog/external-dns)          | `v0.18.0`  | external-dns allows you to manage DNS records natively from Kubernetes.                                                       |
 | [forecastle](katalog/forecastle)              | `v1.0.157` | Forecastle gives you access to a control panel where you can see your ingresses and access them on Kubernetes.                |
@@ -128,9 +128,9 @@ To deploy the `cert-manager` package:
 ```yaml
 bases:
   - name: ingress/dual-nginx
-    version: "v4.1.0"
+    version: "v4.1.1"
   - name: ingress/cert-manager
-    version: "v4.1.0"
+    version: "v4.1.1"
 ```
 
 2. Execute `furyctl vendor -H` to download the packages
@@ -189,7 +189,7 @@ Single Ingress:
 ```yaml
 bases:
   - name: ingress/nginx
-    version: "v4.1.0"
+    version: "v4.1.1"
 ```
 
 Dual Ingress:
@@ -199,9 +199,9 @@ Dual Ingress:
 ```yaml
 bases:
   - name: ingress/nginx
-    version: "v4.1.0"
+    version: "v4.1.1"
   - name: ingress/dual-nginx
-    version: "v4.1.0"
+    version: "v4.1.1"
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
@@ -273,11 +273,11 @@ To deploy the `forecastle` package:
 ```yaml
 bases:
   - name: ingress/dual-nginx
-    version: "v4.1.0"
+    version: "v4.1.1"
   - name: ingress/cert-manager
-    version: "v4.1.0"
+    version: "v4.1.1"
   - name: ingress/forecastle
-    version: "v4.1.0"
+    version: "v4.1.1"
 ```
 
 2. Execute `furyctl legacy vendor -H` to download the packages

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -13,6 +13,7 @@
 | v3.0.1                              |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
 | v4.0.0                              |                    |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
 | v4.1.0                              |                    |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v4.1.1                              |                    |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 :white_check_mark: Compatible
 

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -33,6 +33,7 @@ because it is not officially supported by [SIGHUP](https://sighup.io).
 - :warning: : module version: `v1.12.X` and Kubernetes Version: `1.23.x`. It works as expected. Marked as a warning because it is not officially supported by [SIGHUP](https://sighup.io).
 - :x:: module version: `v1.12.0` has a known bug breaking upgrades. Please do not use.
 - :x:: module version: `v1.12.1` has a known bug breaking upgrades. Please do not use.
+- :warning: : module version: `v4.1.0` with ingress-nginx `v1.13.1` may experience pod stabilization issues depending on environment-specific proxy buffer configurations. Impact varies by environment. Upgrade to `v4.1.1` with ingress-nginx `v1.13.3` to resolve. See [upstream issue #13672](https://github.com/kubernetes/ingress-nginx/issues/13672).
 
 ## Legacy versions
 

--- a/docs/releases/v4.1.1.md
+++ b/docs/releases/v4.1.1.md
@@ -1,0 +1,100 @@
+# Ingress Module Release v4.1.1
+
+
+Welcome to the latest release of `Ingress` module of [`SIGHUP Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+
+This release updates the NGINX Ingress Controller to version 1.13.3 to fix pod stabilization issues. It also introduces support for Kubernetes 1.33 while maintaining compatibility with previous versions.
+
+## Component versions 🚢
+
+| Component          | Supported Version                                                                        | Previous Version |
+| ------------------ | ---------------------------------------------------------------------------------------- | :--------------: |
+| `aws-cert-manager` | N.A.                                                                                     |   `No update`    |
+| `aws-external-dns` | N.A.                                                                                     |   `No update`    |
+| `cert-manager`     | [`v1.18.2`](https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/)     |   `v1.17.1`      |
+| `dual-nginx`       | [`v1.13.3`](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.13.3) |     `1.12.1`     |
+| `external-dns`     | [`v0.18.0`](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.18.0)        |   `v0.16.1`    |
+| `forecastle`       | [`v1.0.157`](https://github.com/stakater/Forecastle/releases/tag/v1.0.157)               |   `v1.0.156`    |
+| `nginx`            | [`v1.13.3`](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.13.3) |     `1.12.1`     |
+
+> Please refer the individual release notes to get a more detailed information on each release.
+
+## New features 🎉
+
+### Kubernetes 1.33 Support
+
+This release adds support for Kubernetes 1.33.x, expanding the compatibility matrix to support Kubernetes versions 1.29 through 1.33.
+
+### NGINX Ingress Controller v1.13.3
+
+Updated to NGINX Ingress Controller v1.13.3 to address pod stabilization issues tracked in [upstream issue #13672](https://github.com/kubernetes/ingress-nginx/issues/13672).
+
+For detailed information about changes in NGINX Ingress Controller v1.13.3, please refer to the [upstream changelog](https://github.com/kubernetes/ingress-nginx/blob/main/changelog/controller-1.13.3.md).
+
+### cert-manager v1.18.2
+
+Updated to cert-manager v1.18.2.
+
+For detailed information about changes in cert-manager v1.18.2, please refer to the [upstream release notes](https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/).
+
+### Forecastle v1.0.157
+
+Updated to Forecastle v1.0.157 with dependency updates including security improvements.
+
+For detailed information about changes in Forecastle v1.0.157, please refer to the [upstream release notes](https://github.com/stakater/Forecastle/releases/tag/v1.0.157).
+
+
+### External-DNS v0.18.0
+
+Updated to External-DNS v0.18.0 for **mandatory** Kubernetes 1.33 compatibility.
+
+#### Important: EndpointSlices Migration
+
+External-DNS v0.18.0 switches from using the Endpoints API to the more scalable EndpointSlices API for discovering Service endpoints. This change:
+- **Improves Performance**: EndpointSlices split large endpoint lists into smaller chunks (100 endpoints per slice), reducing API server load and network traffic
+- **Enables K8s 1.33 Support**: Required for compatibility with Kubernetes 1.33+
+- **Requires RBAC Update**: Adds `discovery.k8s.io/endpointslices` permissions
+
+This is a transparent change for users but significantly improves performance for Services with many pods.
+
+For detailed information about changes in External-DNS v0.18.0, please refer to the [upstream release notes](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.18.0).
+
+
+## Breaking changes 💔
+
+### cert-manager v1.18 ACME HTTP01 Challenge PathType Change
+
+cert-manager v1.18 introduced a breaking change where ACME HTTP01 challenge ingress paths now use `PathType: Exact` instead of `PathType: ImplementationSpecific` for enhanced security and reliable handling across different ingress controllers.
+
+**Compatibility Issue**: This change conflicts with nginx-ingress controller versions >=1.12.0 when the `strict-validate-path-type` option is enabled (default since v1.12.0). The strict validation rejects ACME challenge paths like `/.well-known/acme-challenge/<TOKEN>` when using `PathType: Exact`, causing certificate provisioning to fail.
+
+**Workaround Applied**: This module includes an automatic workaround by setting the cert-manager feature gate `ACMEHTTP01IngressPathTypeExact=false`, which reverts to the previous `PathType: ImplementationSpecific` behavior while maintaining ACME HTTP01 challenge functionality.
+
+For more details, see the [cert-manager v1.18 release notes](https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/#acme-http01-challenge-paths-now-use-pathtype-exact-in-ingress-routes).
+
+## Kubernetes support 🚢
+
+| Kubernetes Version |   Compatibility    | Notes           |
+| ------------------ | :----------------: | --------------- |
+| `1.29.x`           | :white_check_mark: | No known issues |
+| `1.30.x`           | :white_check_mark: | No known issues |
+| `1.31.x`           | :white_check_mark: | No known issues |
+| `1.32.x`           | :white_check_mark: | No known issues |
+| `1.33.x`           | :white_check_mark: | No known issues |
+
+## Upgrade Guide 🦮
+
+> ℹ️ **INFO**
+>
+> This update guide is for users of the module and not of the Distribution or users still on furyctl legacy.
+> If you are a SD user, the update is performed automatically by furyctl.
+
+### Process
+
+To upgrade this core module from `v4.1.0` to `v4.1.1`, you need to download this new version and apply the standard update process.
+
+```bash
+kustomize build <your-project-path> | kubectl apply -f - --server-side
+```
+
+The upgrade process is seamless and does not require any manual intervention.

--- a/docs/releases/v4.1.1.md
+++ b/docs/releases/v4.1.1.md
@@ -11,66 +11,21 @@ This release updates the NGINX Ingress Controller to version 1.13.3 to fix pod s
 | ------------------ | ---------------------------------------------------------------------------------------- | :--------------: |
 | `aws-cert-manager` | N.A.                                                                                     |   `No update`    |
 | `aws-external-dns` | N.A.                                                                                     |   `No update`    |
-| `cert-manager`     | [`v1.18.2`](https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/)     |   `v1.17.1`      |
-| `dual-nginx`       | [`v1.13.3`](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.13.3) |     `1.12.1`     |
-| `external-dns`     | [`v0.18.0`](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.18.0)        |   `v0.16.1`    |
-| `forecastle`       | [`v1.0.157`](https://github.com/stakater/Forecastle/releases/tag/v1.0.157)               |   `v1.0.156`    |
-| `nginx`            | [`v1.13.3`](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.13.3) |     `1.12.1`     |
+| `cert-manager`     | [`v1.18.2`](https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/)     |   `No update`      |
+| `dual-nginx`       | [`v1.13.3`](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.13.3) |     `1.13.1`     |
+| `external-dns`     | [`v0.18.0`](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.18.0)        |   `No update`    |
+| `forecastle`       | [`v1.0.157`](https://github.com/stakater/Forecastle/releases/tag/v1.0.157)               |   `No update`    |
+| `nginx`            | [`v1.13.3`](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.13.3) |     `1.13.1`     |
 
 > Please refer the individual release notes to get a more detailed information on each release.
 
-## New features 🎉
-
-### Kubernetes 1.33 Support
-
-This release adds support for Kubernetes 1.33.x, expanding the compatibility matrix to support Kubernetes versions 1.29 through 1.33.
+## Fixes 🐞
 
 ### NGINX Ingress Controller v1.13.3
 
 Updated to NGINX Ingress Controller v1.13.3 to address pod stabilization issues tracked in [upstream issue #13672](https://github.com/kubernetes/ingress-nginx/issues/13672).
 
 For detailed information about changes in NGINX Ingress Controller v1.13.3, please refer to the [upstream changelog](https://github.com/kubernetes/ingress-nginx/blob/main/changelog/controller-1.13.3.md).
-
-### cert-manager v1.18.2
-
-Updated to cert-manager v1.18.2.
-
-For detailed information about changes in cert-manager v1.18.2, please refer to the [upstream release notes](https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/).
-
-### Forecastle v1.0.157
-
-Updated to Forecastle v1.0.157 with dependency updates including security improvements.
-
-For detailed information about changes in Forecastle v1.0.157, please refer to the [upstream release notes](https://github.com/stakater/Forecastle/releases/tag/v1.0.157).
-
-
-### External-DNS v0.18.0
-
-Updated to External-DNS v0.18.0 for **mandatory** Kubernetes 1.33 compatibility.
-
-#### Important: EndpointSlices Migration
-
-External-DNS v0.18.0 switches from using the Endpoints API to the more scalable EndpointSlices API for discovering Service endpoints. This change:
-- **Improves Performance**: EndpointSlices split large endpoint lists into smaller chunks (100 endpoints per slice), reducing API server load and network traffic
-- **Enables K8s 1.33 Support**: Required for compatibility with Kubernetes 1.33+
-- **Requires RBAC Update**: Adds `discovery.k8s.io/endpointslices` permissions
-
-This is a transparent change for users but significantly improves performance for Services with many pods.
-
-For detailed information about changes in External-DNS v0.18.0, please refer to the [upstream release notes](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.18.0).
-
-
-## Breaking changes 💔
-
-### cert-manager v1.18 ACME HTTP01 Challenge PathType Change
-
-cert-manager v1.18 introduced a breaking change where ACME HTTP01 challenge ingress paths now use `PathType: Exact` instead of `PathType: ImplementationSpecific` for enhanced security and reliable handling across different ingress controllers.
-
-**Compatibility Issue**: This change conflicts with nginx-ingress controller versions >=1.12.0 when the `strict-validate-path-type` option is enabled (default since v1.12.0). The strict validation rejects ACME challenge paths like `/.well-known/acme-challenge/<TOKEN>` when using `PathType: Exact`, causing certificate provisioning to fail.
-
-**Workaround Applied**: This module includes an automatic workaround by setting the cert-manager feature gate `ACMEHTTP01IngressPathTypeExact=false`, which reverts to the previous `PathType: ImplementationSpecific` behavior while maintaining ACME HTTP01 challenge functionality.
-
-For more details, see the [cert-manager v1.18 release notes](https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/#acme-http01-challenge-paths-now-use-pathtype-exact-in-ingress-routes).
 
 ## Kubernetes support 🚢
 

--- a/docs/releases/v4.1.1.md
+++ b/docs/releases/v4.1.1.md
@@ -3,7 +3,7 @@
 
 Welcome to the latest release of `Ingress` module of [`SIGHUP Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
 
-This release updates the NGINX Ingress Controller to version 1.13.3 to fix pod stabilization issues. It also introduces support for Kubernetes 1.33 while maintaining compatibility with previous versions.
+This release updates the NGINX Ingress Controller to version 1.13.3, fixing pod startup failures caused by a hard-coded `proxy_busy_buffers_size` default that conflicted with NGINX's validation when custom proxy buffer configurations were used.
 
 ## Component versions 🚢
 
@@ -12,10 +12,10 @@ This release updates the NGINX Ingress Controller to version 1.13.3 to fix pod s
 | `aws-cert-manager` | N.A.                                                                                     |   `No update`    |
 | `aws-external-dns` | N.A.                                                                                     |   `No update`    |
 | `cert-manager`     | [`v1.18.2`](https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/)     |   `No update`      |
-| `dual-nginx`       | [`v1.13.3`](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.13.3) |     `1.13.1`     |
+| `dual-nginx`       | [`v1.13.3`](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.13.3) |     `v1.13.1`     |
 | `external-dns`     | [`v0.18.0`](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.18.0)        |   `No update`    |
 | `forecastle`       | [`v1.0.157`](https://github.com/stakater/Forecastle/releases/tag/v1.0.157)               |   `No update`    |
-| `nginx`            | [`v1.13.3`](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.13.3) |     `1.13.1`     |
+| `nginx`            | [`v1.13.3`](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.13.3) |     `v1.13.1`     |
 
 > Please refer the individual release notes to get a more detailed information on each release.
 
@@ -23,9 +23,9 @@ This release updates the NGINX Ingress Controller to version 1.13.3 to fix pod s
 
 ### NGINX Ingress Controller v1.13.3
 
-Updated to NGINX Ingress Controller v1.13.3 to address pod stabilization issues tracked in [upstream issue #13672](https://github.com/kubernetes/ingress-nginx/issues/13672).
+Updated to NGINX Ingress Controller v1.13.3, fixing pod startup failures caused by a hard-coded `proxy_busy_buffers_size` default that conflicted with NGINX's validation when custom proxy buffer configurations were used. The fix removes the hard-coded default, see [upstream issue #13672](https://github.com/kubernetes/ingress-nginx/issues/13672) for details.
 
-For detailed information about changes in NGINX Ingress Controller v1.13.3, please refer to the [upstream changelog](https://github.com/kubernetes/ingress-nginx/blob/main/changelog/controller-1.13.3.md).
+For additional information about changes in NGINX Ingress Controller v1.13.3, please refer to the [upstream changelog](https://github.com/kubernetes/ingress-nginx/blob/main/changelog/controller-1.13.3.md).
 
 ## Kubernetes support 🚢
 

--- a/examples/nginx-config/Furyfile.yml
+++ b/examples/nginx-config/Furyfile.yml
@@ -4,4 +4,4 @@
 
 bases:
   - name: ingress/nginx
-    version: v1.13.1
+    version: v1.13.3

--- a/examples/nginx-default-ssl-certificate/Furyfile.yml
+++ b/examples/nginx-default-ssl-certificate/Furyfile.yml
@@ -4,4 +4,4 @@
 
 bases:
   - name: ingress/nginx
-    version: v1.13.1
+    version: v1.13.3

--- a/examples/nginx-gke/README.md
+++ b/examples/nginx-gke/README.md
@@ -29,7 +29,7 @@ NGINX GKE is deployed with following default configuration:
 ```yaml
 bases:
   - name: ingress/nginx
-    version: "v1.13.1"
+    version: "v1.13.3"
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.

--- a/examples/nginx-ovh/README.md
+++ b/examples/nginx-ovh/README.md
@@ -29,7 +29,7 @@ NGINX OVH is deployed with the following default configuration:
 ```yaml
 bases:
   - name: ingress/nginx
-    version: "v1.13.1"
+    version: "v1.13.3"
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.

--- a/katalog/dual-nginx/README.md
+++ b/katalog/dual-nginx/README.md
@@ -12,7 +12,7 @@ Ingress NGINX is an Ingress Controller for [NGINX][nginx-page] webserver and rev
 
 ## Image repository and tag
 
-- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.13.1`
+- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.13.3`
 - Ingress NGINX repo: [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
 
 ## Configuration

--- a/katalog/nginx/MAINTENANCE.md
+++ b/katalog/nginx/MAINTENANCE.md
@@ -2,7 +2,7 @@
 
 **Current Version**: v1.13.3 (Helm Chart 4.13.3)
 **Previous Version**: v1.13.1 (Helm Chart 4.13.0)
-**Last Updated**: October 2025 for ingress-nginx bug fixe
+**Last Updated**: October 2025 for ingress-nginx bug fix
 
 To update Ingress NGINX controller, follow the next steps (or update and use the [upgrade.sh](./upgrade.sh) script to automate it):
 

--- a/katalog/nginx/MAINTENANCE.md
+++ b/katalog/nginx/MAINTENANCE.md
@@ -1,8 +1,8 @@
 # Ingress NGINX controller package maintenance guide
 
-**Current Version**: v1.13.1 (Helm Chart 4.13.0)  
-**Previous Version**: v1.12.1 (Helm Chart 4.12.0)  
-**Last Updated**: August 2025 for Kubernetes 1.33 compatibility  
+**Current Version**: v1.13.3 (Helm Chart 4.13.3)
+**Previous Version**: v1.13.1 (Helm Chart 4.13.0)
+**Last Updated**: October 2025 for ingress-nginx bug fixe
 
 To update Ingress NGINX controller, follow the next steps (or update and use the [upgrade.sh](./upgrade.sh) script to automate it):
 

--- a/katalog/nginx/MAINTENANCE.values.yml
+++ b/katalog/nginx/MAINTENANCE.values.yml
@@ -10,7 +10,7 @@ controller:
   image:
     registry: registry.sighup.io
     image: fury/ingress-nginx/controller
-    tag: "v1.13.1"
+    tag: "v1.13.3"
     pullPolicy: Always
     digest: ""
   containerPort:

--- a/katalog/nginx/README.md
+++ b/katalog/nginx/README.md
@@ -12,7 +12,7 @@ Ingress NGINX is an Ingress Controller for [NGINX][nginx-page] web server and re
 
 ## Image repository and tag
 
-- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.13.1`
+- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.13.3`
 - Ingress NGINX repo: [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
 
 ## Configuration

--- a/katalog/nginx/bases/configs/ClusterRole-ingress-nginx.yml
+++ b/katalog/nginx/bases/configs/ClusterRole-ingress-nginx.yml
@@ -8,10 +8,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.13.0
+    helm.sh/chart: ingress-nginx-4.13.3
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.13.1"
+    app.kubernetes.io/version: "1.13.3"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
   name: ingress-nginx

--- a/katalog/nginx/bases/configs/ClusterRoleBinding-ingress-nginx.yml
+++ b/katalog/nginx/bases/configs/ClusterRoleBinding-ingress-nginx.yml
@@ -8,10 +8,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.13.0
+    helm.sh/chart: ingress-nginx-4.13.3
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.13.1"
+    app.kubernetes.io/version: "1.13.3"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
   name: ingress-nginx

--- a/katalog/nginx/bases/configs/PrometheusRule-ingress-nginx-controller.yml
+++ b/katalog/nginx/bases/configs/PrometheusRule-ingress-nginx-controller.yml
@@ -10,10 +10,10 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
   labels:
-    helm.sh/chart: ingress-nginx-4.13.0
+    helm.sh/chart: ingress-nginx-4.13.3
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.13.1"
+    app.kubernetes.io/version: "1.13.3"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/configs/Role-ingress-nginx.yml
+++ b/katalog/nginx/bases/configs/Role-ingress-nginx.yml
@@ -8,10 +8,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.13.0
+    helm.sh/chart: ingress-nginx-4.13.3
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.13.1"
+    app.kubernetes.io/version: "1.13.3"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/configs/RoleBinding-ingress-nginx.yml
+++ b/katalog/nginx/bases/configs/RoleBinding-ingress-nginx.yml
@@ -8,10 +8,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.13.0
+    helm.sh/chart: ingress-nginx-4.13.3
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.13.1"
+    app.kubernetes.io/version: "1.13.3"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/configs/Service-ingress-nginx-controller-metrics.yml
+++ b/katalog/nginx/bases/configs/Service-ingress-nginx-controller-metrics.yml
@@ -8,10 +8,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.13.0
+    helm.sh/chart: ingress-nginx-4.13.3
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.13.1"
+    app.kubernetes.io/version: "1.13.3"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/configs/ServiceAccount-ingress-nginx.yml
+++ b/katalog/nginx/bases/configs/ServiceAccount-ingress-nginx.yml
@@ -8,10 +8,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.13.0
+    helm.sh/chart: ingress-nginx-4.13.3
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.13.1"
+    app.kubernetes.io/version: "1.13.3"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/configs/ServiceMonitor-ingress-nginx-controller.yml
+++ b/katalog/nginx/bases/configs/ServiceMonitor-ingress-nginx-controller.yml
@@ -10,10 +10,10 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
   labels:
-    helm.sh/chart: ingress-nginx-4.13.0
+    helm.sh/chart: ingress-nginx-4.13.3
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.13.1"
+    app.kubernetes.io/version: "1.13.3"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/controller/ConfigMap-ingress-nginx-controller.yml
+++ b/katalog/nginx/bases/controller/ConfigMap-ingress-nginx-controller.yml
@@ -8,10 +8,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.13.0
+    helm.sh/chart: ingress-nginx-4.13.3
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.13.1"
+    app.kubernetes.io/version: "1.13.3"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/controller/DaemonSet-ingress-nginx-controller.yml
+++ b/katalog/nginx/bases/controller/DaemonSet-ingress-nginx-controller.yml
@@ -8,10 +8,10 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.13.0
+    helm.sh/chart: ingress-nginx-4.13.3
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.13.1"
+    app.kubernetes.io/version: "1.13.3"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -33,10 +33,10 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: ingress-nginx-4.13.0
+        helm.sh/chart: ingress-nginx-4.13.3
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/version: "1.13.1"
+        app.kubernetes.io/version: "1.13.3"
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: controller
@@ -46,7 +46,7 @@ spec:
         fsGroup: 101
       containers:
         - name: controller
-          image: registry.sighup.io/fury/ingress-nginx/controller:v1.13.1
+          image: registry.sighup.io/fury/ingress-nginx/controller:v1.13.3
           imagePullPolicy: Always
           lifecycle:
             preStop:

--- a/katalog/nginx/bases/controller/IngressClass-nginx.yml
+++ b/katalog/nginx/bases/controller/IngressClass-nginx.yml
@@ -8,10 +8,10 @@ apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.13.0
+    helm.sh/chart: ingress-nginx-4.13.3
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.13.1"
+    app.kubernetes.io/version: "1.13.3"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/controller/Service-ingress-nginx-controller-admission.yml
+++ b/katalog/nginx/bases/controller/Service-ingress-nginx-controller-admission.yml
@@ -8,10 +8,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.13.0
+    helm.sh/chart: ingress-nginx-4.13.3
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.13.1"
+    app.kubernetes.io/version: "1.13.3"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/controller/Service-ingress-nginx-controller.yml
+++ b/katalog/nginx/bases/controller/Service-ingress-nginx-controller.yml
@@ -9,10 +9,10 @@ kind: Service
 metadata:
   annotations:
   labels:
-    helm.sh/chart: ingress-nginx-4.13.0
+    helm.sh/chart: ingress-nginx-4.13.3
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.13.1"
+    app.kubernetes.io/version: "1.13.3"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/controller/ValidatingWebhookConfiguration-ingress-nginx-admission.yml
+++ b/katalog/nginx/bases/controller/ValidatingWebhookConfiguration-ingress-nginx-admission.yml
@@ -13,10 +13,10 @@ metadata:
     certmanager.k8s.io/inject-ca-from: "ingress-nginx/ingress-nginx-admission"
     cert-manager.io/inject-ca-from: "ingress-nginx/ingress-nginx-admission"
   labels:
-    helm.sh/chart: ingress-nginx-4.13.0
+    helm.sh/chart: ingress-nginx-4.13.3
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.13.1"
+    app.kubernetes.io/version: "1.13.3"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook

--- a/katalog/nginx/bases/controller/kustomization.yaml
+++ b/katalog/nginx/bases/controller/kustomization.yaml
@@ -16,7 +16,7 @@ labels:
 images:
   - name: k8s.gcr.io/ingress-nginx/controller
     newName: registry.sighup.io/fury/ingress-nginx/controller
-    newTag: v1.13.1
+    newTag: v1.13.3
 
 resources:
   - Certificate-ingress-nginx-admission.yml

--- a/katalog/nginx/upgrade.sh
+++ b/katalog/nginx/upgrade.sh
@@ -7,7 +7,7 @@
 kustomize build . > current-release.yaml
 
 # Remember to change this version accordingly
-VERSION=4.12.0
+VERSION=4.13.3
 
 helm template ingress-nginx ingress-nginx \
   --repo https://kubernetes.github.io/ingress-nginx \


### PR DESCRIPTION
### Summary 💡

Upgrade ingress-nginx controller from v1.13.1 to v1.13.3 (chart 4.13.3) to fix pod startup failures caused by a hard-coded `proxy_busy_buffers_size` default that conflicted with NGINX's validation when custom proxy buffer configurations were used.

### Description 📝

Changes:
- Updated controller image tag from `v1.13.1` to `v1.13.3`
- Updated Helm chart version from `4.13.0` to `4.13.3`
- Updated `MAINTENANCE.md` and `MAINTENANCE.values.yml`
- Updated `README.md` with v1.13.3 versions
- Updated release notes
- Updated `docs/COMPATIBILITY_MATRIX.md`

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Tested with the ingress-nginx controller v1.13.3 in a local kind cluster
- [x] CI: [ci.sighup.io/sighupio/module-ingress/1385](https://ci.sighup.io/sighupio/module-ingress/1385)

### Future work 🔧

None.